### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,28 @@
-language: python
-python:
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-script: python tests/all_tests.py
+name: Python Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt  # Ensure you have this file
+          pip install pytest  # Adjust if using another test framework
+
+      - name: Run Tests
+        run: python -m pytest tests/


### PR DESCRIPTION
✅ Modern and faster (Travis is outdated)
✅ Runs on GitHub Actions for free
✅ Supports Python 3.6+ (drops 2.7, which is obsolete) 
✅ Uses pytest, but can be modified for other test frameworks